### PR TITLE
npmignore på csproj- och sln-filer

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,4 +18,5 @@ Images/
 garbageDir/
 obj/
 tools/
-
+Komponentkartan.csproj
+Komponentkartan.sln


### PR DESCRIPTION
Komponentkartan.csproj och Komponentkartan.sln publiceras på npm-repositoryn. Denna ändring borde förhindra detta.