### PR TITLE
Dropdown CSS refaktorering efter tillägg av .dropdown klassen

### DIFF
--- a/Content/partials/_components.dropdown.scss
+++ b/Content/partials/_components.dropdown.scss
@@ -4,7 +4,7 @@ $dropdown-height--medium-with-filter: 360px;
 $dropdown-width--medium: 160px;
 $dropdown-width--small: 100px;
 $filter-area-height: 60px;
-.dropdown-new {
+.dropdown {
   .dropdown--readonly {
     display: block;
     opacity: 0;
@@ -37,7 +37,7 @@ $filter-area-height: 60px;
   }
 }
 
-.dropdown {
+.dropdown--edit {
   @extend .background-color--primary;
   position: relative;
   display: inline-block;
@@ -291,7 +291,7 @@ $filter-area-height: 60px;
 }
 
 @media screen and (min-width: $desktop-width--medium) {
-  .dropdown {
+  .dropdown--edit {
     width: $dropdown-width--medium + $margin--slim;
     span {
       width: calc(#{$dropdown-width--medium} + 10px - #{$icon-width} - #{$border--single} - #{$border--single});

--- a/component-package/controls/dropdown-base/dropdown.base.component.ts
+++ b/component-package/controls/dropdown-base/dropdown.base.component.ts
@@ -20,7 +20,7 @@ export abstract class DropdownBaseComponent extends ValidationComponent {
     @Input() required: boolean;
     @Input() @HostBinding('class.readonly') readonly: boolean;
     @Input() @HostBinding('class.disabled') disabled: boolean;
-    @HostBinding('class.dropdown-new') dropdownClass = true;
+    @HostBinding('class.dropdown') dropdownClass = true;
 
     showAllItem: IDropdownItem;
 

--- a/component-package/controls/dropdown-base/dropdown.base.component.ts
+++ b/component-package/controls/dropdown-base/dropdown.base.component.ts
@@ -47,7 +47,7 @@ export abstract class DropdownBaseComponent extends ValidationComponent {
             this.handleInitiallySelectedItems(selectedItems);
         }
         setTimeout(() => {
-            if (this.readonly === false && this.disabled === false) {
+            if (!this.readonly && !this.disabled) {
                 this.scrollbarComponent.update();
                 this.listenToScrollbarEvents();
             }
@@ -103,7 +103,6 @@ export abstract class DropdownBaseComponent extends ValidationComponent {
             scrollbar.prev('.dropdown__dimmer--top').show();
         }
     }
-
 
     filterItems(filterValue: string) {
         this.filter = filterValue;

--- a/component-package/controls/dropdown-multiselect/dropdown-multiselect.component.html
+++ b/component-package/controls/dropdown-multiselect/dropdown-multiselect.component.html
@@ -1,5 +1,5 @@
 <div class="validation">
-  <div class="dropdown dropdown--multiselect" [ngClass]="{'dropdown--open' : expanded, 'dropdown--filter-visible' : filterVisible, 'dropdown--scroll-visible' : scrollVisible}"
+  <div class="dropdown--edit dropdown--multiselect" [ngClass]="{'dropdown--open' : expanded, 'dropdown--filter-visible' : filterVisible, 'dropdown--scroll-visible' : scrollVisible}"
     (mousedown)="onDropdownMouseDown($event)" (focusout)="onLeave()" (focusin)="onEnter()" tabindex="{{disabled ? -1 : 0}}">
     <span tabindex="0">{{dropdownLabel}}</span>
     <div class="dropdown__menu">

--- a/component-package/controls/dropdown/dropdown.component.html
+++ b/component-package/controls/dropdown/dropdown.component.html
@@ -1,5 +1,5 @@
 <div class="validation">
-  <div class="dropdown" [ngClass]="{'dropdown--open' : expanded, 'dropdown--filter-visible' : filterVisible, 'dropdown--scroll-visible' : scrollVisible}"
+  <div class="dropdown--edit" [ngClass]="{'dropdown--open' : expanded, 'dropdown--filter-visible' : filterVisible, 'dropdown--scroll-visible' : scrollVisible}"
     (mousedown)="onDropdownMouseDown($event)" (focusout)="onLeave()" (focusin)="onEnter()" tabindex="{{disabled ? -1 : 0}}">
     <span tabIndex="0" *ngIf="selectedItem" title="{{selectedItem.displayName}}">{{ selectedItem | dropdownItemToSelectedText | truncate:14 }}</span>
     <span tabIndex="0" *ngIf="!selectedItem" title="{{noItemSelectedLabel}}">{{readonly ? '' : (noItemSelectedLabel | truncate:14) }}</span>

--- a/tests/controls/dropdownComponent.angular.spec.ts
+++ b/tests/controls/dropdownComponent.angular.spec.ts
@@ -42,7 +42,7 @@ describe('DropdownComponent', () => {
     describe('When component is initialized', () => {
         let dropdownElement: DebugElement;
         beforeEach(() => {
-            dropdownElement = rootElement.query(By.css('.dropdown'));
+            dropdownElement = rootElement.query(By.css('.dropdown--edit'));
             component.showAllItemText = 'Select all';
             component.ngOnChanges();
         });
@@ -299,7 +299,7 @@ describe('DropdownComponent', () => {
 
         beforeEach(() => {
             component.items = [{ displayName: 'one' }, { displayName: 'two', selected: true }, { displayName: 'three' }] as IDropdownItem[];
-            dropdownElement = rootElement.query(By.css('.dropdown'));
+            dropdownElement = rootElement.query(By.css('.dropdown--edit'));
             fixture.detectChanges();
             selectedItemSpan = dropdownElement.query(By.css('span'));
         });
@@ -316,7 +316,7 @@ describe('DropdownComponent', () => {
         let selectedItemSpan: DebugElement;
         beforeEach(() => {
             component.items = [{ displayName: 'one', selected: true }, { displayName: 'two', selected: true }, { displayName: 'three' }] as IDropdownItem[];
-            dropdownElement = rootElement.query(By.css('.dropdown'));
+            dropdownElement = rootElement.query(By.css('.dropdown--edit'));
             fixture.detectChanges();
             selectedItemSpan = dropdownElement.query(By.css('span'));
         });
@@ -365,7 +365,7 @@ describe('DropdownComponent', () => {
         });
 
         it('should have empty selected items text', () => {
-            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown > span'));
+            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown--edit > span'));
             const content = selectedItemsSpan.nativeElement.textContent;
             expect(content.trim()).toBe('');
         });
@@ -384,7 +384,7 @@ describe('DropdownComponent', () => {
         });
 
         it('should display selected item text', () => {
-            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown > span'));
+            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown--edit > span'));
             const content = selectedItemsSpan.nativeElement.textContent;
             expect(content.trim()).toBe('one');
         });
@@ -401,7 +401,7 @@ describe('DropdownComponent', () => {
         });
 
         it('should have empty selected items text', () => {
-            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown > span'));
+            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown--edit > span'));
             const content = selectedItemsSpan.nativeElement.textContent;
             expect(content.trim()).toBe('');
         });
@@ -420,7 +420,7 @@ describe('DropdownComponent', () => {
         });
 
         it('should display selected item text', () => {
-            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown > span'));
+            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown--edit > span'));
             const content = selectedItemsSpan.nativeElement.textContent;
             expect(content.trim()).toBe('two');
         });

--- a/tests/controls/dropdownMultiselectComponent.angular.spec.ts
+++ b/tests/controls/dropdownMultiselectComponent.angular.spec.ts
@@ -68,7 +68,7 @@ describe("[DropdownMultiSelectComponent]", () => {
     describe("When component is initialized", () => {
         var dropdownElement: DebugElement;
         beforeEach(() => {
-            dropdownElement = rootElement.query(By.css(".dropdown"));
+            dropdownElement = rootElement.query(By.css(".dropdown--edit"));
 
         });
         it("dropdown is not expanded", () => {
@@ -142,7 +142,7 @@ describe("[DropdownMultiSelectComponent]", () => {
     describe("when dropdown is clicked", () => {
         var dropdownElement: DebugElement;
         beforeEach(() => {
-            dropdownElement = rootElement.query(By.css(".dropdown"));
+            dropdownElement = rootElement.query(By.css(".dropdown--edit"));
             dropdownElement.triggerEventHandler("mousedown", { target: dropdownElement.nativeElement } as MouseEvent);
             fixture.detectChanges();
         });
@@ -248,7 +248,7 @@ describe("[DropdownMultiSelectComponent]", () => {
     describe("when dropdown is open", () => {
         var dropdownElement: DebugElement;
         beforeEach(() => {
-            dropdownElement = rootElement.query(By.css(".dropdown"));
+            dropdownElement = rootElement.query(By.css(".dropdown--edit"));
             component.expanded = true;
             fixture.detectChanges();
         });
@@ -301,7 +301,7 @@ describe("[DropdownMultiSelectComponent]", () => {
             fixture.detectChanges();
         });
         it("the filter textbox is visible", () => {
-            let dropdownElement = rootElement.query(By.css(".dropdown"));
+            let dropdownElement = rootElement.query(By.css(".dropdown--edit"));
             expect(dropdownElement.classes["dropdown--filter-visible"]).toBe(true);
         });
 
@@ -361,7 +361,7 @@ describe("[DropdownMultiSelectComponent]", () => {
             fixture.detectChanges();
         });
         it("the filter textbox is not visible", () => {
-            let dropdownElement = rootElement.query(By.css(".dropdown"));
+            let dropdownElement = rootElement.query(By.css(".dropdown--edit"));
             expect(dropdownElement.classes["dropdown--filter-visible"]).toBe(false);
         });
     });
@@ -415,7 +415,7 @@ describe("[DropdownMultiSelectComponent]", () => {
         });
 
         it('should display "Välj"', () => {
-            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown > span'));
+            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown--edit > span'));
             const content = selectedItemsSpan.nativeElement.textContent;
             expect(content.trim()).toBe('Välj');
         });
@@ -434,7 +434,7 @@ describe("[DropdownMultiSelectComponent]", () => {
         });
 
         it('should display a text with the number of items selected', () => {
-            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown > span'));
+            const selectedItemsSpan = fixture.debugElement.query(By.css('.dropdown--edit > span'));
             const content = selectedItemsSpan.nativeElement.textContent;
             expect(content.trim()).toBe('2 valda');
         });
@@ -449,7 +449,7 @@ describe("[DropdownMultiSelectComponent]", () => {
         });
 
         it('should display an ul with selected items', () => {
-            const selectedItemslist = fixture.debugElement.queryAll(By.css('.dropdown__multiselect-readonlylist ul li'));     
+            const selectedItemslist = fixture.debugElement.queryAll(By.css('.dropdown__multiselect-readonlylist ul li'));
             expect(selectedItemslist.length).toBe(2);
             expect(selectedItemslist[0].nativeElement.textContent).toBe('one');
             expect(selectedItemslist[1].nativeElement.textContent).toBe('two');


### PR DESCRIPTION
Efter mina och Felicias ändringar lämnade vi kvar ett behov av refaktorering av klassnamn. Detta är nu gjort tillsammans med en buggrättning som gjorde att dimmer inte doldes längst upp och ner i listan.