### PR TITLE
Revert css animationer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgr-komponentkartan",
-  "version": "2.0.1-rc11",
+  "version": "2.0.1-rc12",
   "author": "Västra Götalandsregionen",
   "license": "MIT",
   "scripts": {

--- a/src/app/example-layout/example-layout.component.html
+++ b/src/app/example-layout/example-layout.component.html
@@ -19,34 +19,6 @@
         <vgr-expandable-div-content>
           <p>Lite innehåll</p>
           <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
         </vgr-expandable-div-content>
       </vgr-expandable-div>
       <vgr-expandable-div [expanded]="true" (expandedChanged)="onExpandedChanged($event)">
@@ -54,20 +26,6 @@
           <p>Denna div är expanded från början
         </vgr-expandable-div-header>
         <vgr-expandable-div-content>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
-          <p>Lite innehåll</p>
-          <p>Mer innehåll</p>
           <p>Lite innehåll</p>
           <p>Mer innehåll</p>
         </vgr-expandable-div-content>

--- a/src/assets/partials/_components.card.scss
+++ b/src/assets/partials/_components.card.scss
@@ -89,6 +89,7 @@
 }
 
 .card-section__header__expander {
+  @extend .bg-image-icon-chevron;
   display: inline-block;
   margin-right: $margin--slim;
   width: 15px;
@@ -96,27 +97,18 @@
   background-size: 100%;
   vertical-align: middle;
   margin-left: auto;
-  &.expanded {
-    @extend .chevron-expanded;
-  }
-  &.collapsed {
-    @extend .chevron-collapsed;
+  transform: rotate(0deg);
+  transition: transform 0.4s;
+  .card-section--expanded & {
+    transform: rotate(-180deg);
+    transition: transform 0.4s;
   }
 }
 
 .card-section__content {
-  .card-section--collapsed & {
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.4s ease-in, padding 0.4s ease-in;
-  }
-  .card-section--expanded & {
-    max-height: 999px;
-    overflow: hidden;
-    transition: max-height 0.4s ease-out, padding 0.4s ease-in-out;
-    padding-bottom: $margin--slim;
-    padding-top: $margin--slim;
-  }
+  padding-bottom: $margin--slim;
+  display: none;
+  padding-top: $margin--slim;
 }
 
 @media screen and (min-width: $desktop-width--medium) {

--- a/src/assets/partials/_components.expandableDiv.component.scss
+++ b/src/assets/partials/_components.expandableDiv.component.scss
@@ -18,16 +18,7 @@
   }
   &.expandable-div--collapsed {
     .expandable-div-content {
-      max-height: 0;
-      overflow: hidden;
-      transition: max-height 0.4s ease-in;
-    }
-  }
-  &.expandable-div--expanded {
-    .expandable-div-content {
-      max-height: 999px;
-      overflow: hidden;
-      transition: max-height 0.4s ease-out;
+      display: none;
     }
   }
 }

--- a/src/assets/partials/_components.list.scss
+++ b/src/assets/partials/_components.list.scss
@@ -228,18 +228,10 @@
     border-top: none;
     padding-top: 0;
   }
-  .list-item--collapsed & {
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.4s ease-in;
-  }
   .list-item--expanded & {
     // jQuery slideUp verkar sätta display inline. Blir ej bra.
     // Lyckades inte overridea så detta löser problemet (om än inte på ett snyggt sätt)
-    display: block;
-    max-height: 999px;
-    overflow: hidden;
-    transition: max-height 0.4s ease-out;
+    display: block !important;
   }
 }
 

--- a/src/assets/partials/_components.list.scss
+++ b/src/assets/partials/_components.list.scss
@@ -228,10 +228,18 @@
     border-top: none;
     padding-top: 0;
   }
+  .list-item--collapsed & {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.4s ease-in;
+  }
   .list-item--expanded & {
     // jQuery slideUp verkar sätta display inline. Blir ej bra.
     // Lyckades inte overridea så detta löser problemet (om än inte på ett snyggt sätt)
     display: block;
+    max-height: 999px;
+    overflow: hidden;
+    transition: max-height 0.4s ease-out;
   }
 }
 

--- a/src/lib/controls/card/cardSection.component.html
+++ b/src/lib/controls/card/cardSection.component.html
@@ -2,8 +2,8 @@
   <h2 class="card-section__header__title noselect">{{title}}</h2>
   <h4 class="card-section__header__subtitle" *ngIf="subtitle && subtitle.length>0" title="{{subtitle}}">{{subtitle|truncate:30}}</h4>
   <div class="card-section__header__icon"></div>
-  <div [className]="chevron_class"></div>
+  <div class="card-section__header__expander"></div>
 </div>
 <div class="card-section__content">
-  <ng-content *ngIf="expanded_chevron"></ng-content>
+  <ng-content></ng-content>
 </div>

--- a/src/lib/controls/card/cardSection.component.html
+++ b/src/lib/controls/card/cardSection.component.html
@@ -5,5 +5,5 @@
   <div [className]="chevron_class"></div>
 </div>
 <div class="card-section__content">
-  <ng-content *ngIf="showContent"></ng-content>
+  <ng-content *ngIf="expanded_chevron"></ng-content>
 </div>

--- a/src/lib/controls/card/cardSection.component.ts
+++ b/src/lib/controls/card/cardSection.component.ts
@@ -5,43 +5,34 @@ import { Component, HostBinding, Input, ElementRef, AfterContentInit } from '@an
     moduleId: module.id,
     templateUrl: './cardSection.component.html'
 })
-export class CardSectionComponent {
-
-    private expanded_chevron;
-
+export class CardSectionComponent implements AfterContentInit {
+    @HostBinding('class.card-section') cardSectionClass = true;
+    @HostBinding('class.card-section--expanded') private _expanded: boolean;
+    @Input() @HostBinding('class.card-section--readonly') readonly: boolean;
     @Input() title: string;
     @Input() subtitle: string;
-
-    @HostBinding('class.card-section') cardSectionClass = true;
-    @Input() @HostBinding('class.card-section--readonly') readonly: boolean;
-    @HostBinding('class.card-section--expanded') private _expanded: boolean;
-    @HostBinding('class.card-section--collapsed')
-    get isCollapsed() {
-        return !this._expanded;
+    @Input() set expanded(value: boolean) {
+        this._expanded = value;
+        this.setContentOpenOrClosed();
     }
-
-    @Input() set expanded(expandedValue: boolean) {
-        if (expandedValue && !this._expanded) {
-            this._expanded = true;
-            this.expanded_chevron = true;
-        } else if (!expandedValue && this._expanded) {
-            this._expanded = false;
-            setTimeout(() => {
-                this.expanded_chevron = false;
-            }, 400);
-        }
-    }
-
     get expanded(): boolean {
         return this._expanded;
     }
 
-    get chevron_class() {
-        return 'card-section__header__expander  '.concat(this.expanded_chevron ? 'expanded' : 'collapsed');
+    private setContentOpenOrClosed() {
+        if (this._expanded) {
+            $(this.elementRef.nativeElement).children('.card-section__content').slideDown(400);
+        } else {
+            $(this.elementRef.nativeElement).children('.card-section__content').slideUp(400);
+        }
+    }
+    ngAfterContentInit() {
+        setTimeout(() => {
+            this.setContentOpenOrClosed();
+        }, 10);
     }
     constructor(private elementRef: ElementRef) {
         this.readonly = true;
     }
+
 }
-
-

--- a/src/lib/controls/card/cardSection.component.ts
+++ b/src/lib/controls/card/cardSection.component.ts
@@ -7,7 +7,7 @@ import { Component, HostBinding, Input, ElementRef, AfterContentInit } from '@an
 })
 export class CardSectionComponent {
 
-    showContent: boolean;
+    private expanded_chevron;
 
     @Input() title: string;
     @Input() subtitle: string;
@@ -23,11 +23,11 @@ export class CardSectionComponent {
     @Input() set expanded(expandedValue: boolean) {
         if (expandedValue && !this._expanded) {
             this._expanded = true;
-            this.showContent = true;
+            this.expanded_chevron = true;
         } else if (!expandedValue && this._expanded) {
             this._expanded = false;
             setTimeout(() => {
-                this.showContent = false;
+                this.expanded_chevron = false;
             }, 400);
         }
     }
@@ -37,7 +37,7 @@ export class CardSectionComponent {
     }
 
     get chevron_class() {
-        return 'card-section__header__expander  '.concat(this.showContent ? 'expanded' : 'collapsed');
+        return 'card-section__header__expander  '.concat(this.expanded_chevron ? 'expanded' : 'collapsed');
     }
     constructor(private elementRef: ElementRef) {
         this.readonly = true;

--- a/src/lib/controls/expandableDiv/expandableDiv.angular.spec.ts
+++ b/src/lib/controls/expandableDiv/expandableDiv.angular.spec.ts
@@ -53,7 +53,6 @@ describe('[ExpandableDivComponent]', () => {
         });
 
 
-        // Todo, få bortkommenterade testet att lira.
         describe('and header is clicked', () => {
             beforeEach(() => {
                 header = rootElement.query(By.css('.expandable-div-header'));
@@ -62,7 +61,8 @@ describe('[ExpandableDivComponent]', () => {
             });
 
             it('div is collapsed', () => {
-                expect(component.expanded).toBe(false);
+                // TODO: Test funkar inte pga fördröjning på 400ms
+                // expect(component.expanded).toBe(false);
             });
 
             describe('and header is clicked again', () => {
@@ -88,7 +88,6 @@ describe('[ExpandableDivComponent]', () => {
             expect(rootElement.classes['expandable-div--expanded']).toBe(false);
         });
 
-        // Todo, få bortkommenterade testet att lira.
         describe('and header is clicked', () => {
             beforeEach(() => {
                 header = rootElement.query(By.css('.expandable-div-header'));
@@ -105,7 +104,8 @@ describe('[ExpandableDivComponent]', () => {
                     fixture.detectChanges();
                 });
                 it('div is collapsed', () => {
-                    expect(component.expanded).toBe(false);
+                    // TODO: Test funkar inte pga fördröjning på 400ms
+                    // expect(component.expanded).toBe(false);
                 });
             });
         });

--- a/src/lib/controls/expandableDiv/expandableDiv.component.html
+++ b/src/lib/controls/expandableDiv/expandableDiv.component.html
@@ -3,5 +3,5 @@
   <ng-content select="vgr-expandable-div-header"></ng-content>
 </div>
 <div class="expandable-div-content">
-  <ng-content *ngIf="showContent" select="vgr-expandable-div-content"></ng-content>
+  <ng-content *ngIf="expanded_chevron" select="vgr-expandable-div-content"></ng-content>
 </div>

--- a/src/lib/controls/expandableDiv/expandableDiv.component.html
+++ b/src/lib/controls/expandableDiv/expandableDiv.component.html
@@ -3,5 +3,5 @@
   <ng-content select="vgr-expandable-div-header"></ng-content>
 </div>
 <div class="expandable-div-content">
-  <ng-content *ngIf="expanded_chevron" select="vgr-expandable-div-content"></ng-content>
+  <ng-content select="vgr-expandable-div-content"></ng-content>
 </div>

--- a/src/lib/controls/expandableDiv/expandableDiv.component.ts
+++ b/src/lib/controls/expandableDiv/expandableDiv.component.ts
@@ -12,10 +12,7 @@ export class ExpandableDivComponent {
 
     @HostBinding('class.expandable-div--expanded') private _expanded: boolean;
     @HostBinding('class.expandable-div') private expandableDivClass = true;
-    @HostBinding('class.expandable-div--collapsed')
-    get isCollapsed() {
-        return !this._expanded;
-    }
+    @HostBinding('class.expandable-div--collapsed') isCollapsed() { return !this._expanded; }
 
     @Input() set expanded(expandedValue: boolean) {
         if (expandedValue && !this._expanded) {

--- a/src/lib/controls/expandableDiv/expandableDiv.component.ts
+++ b/src/lib/controls/expandableDiv/expandableDiv.component.ts
@@ -21,12 +21,10 @@ export class ExpandableDivComponent {
         if (expandedValue && !this._expanded) {
             this._expanded = true;
             this.showContent = true;
-            this.expandedChanged.emit(this._expanded);
         } else if (!expandedValue && this._expanded) {
             this._expanded = false;
             setTimeout(() => {
                 this.showContent = false;
-                this.expandedChanged.emit(this._expanded);
             }, 400);
         }
     }

--- a/src/lib/controls/expandableDiv/expandableDiv.component.ts
+++ b/src/lib/controls/expandableDiv/expandableDiv.component.ts
@@ -6,7 +6,7 @@ import { Input, Component, HostBinding, ContentChild, ElementRef, Output, EventE
     templateUrl: './expandableDiv.component.html',
 })
 export class ExpandableDivComponent {
-    showContent: boolean;
+    private expanded_chevron: boolean;
 
     @Output() expandedChanged: EventEmitter<boolean> = new EventEmitter<boolean>();
 
@@ -20,11 +20,11 @@ export class ExpandableDivComponent {
     @Input() set expanded(expandedValue: boolean) {
         if (expandedValue && !this._expanded) {
             this._expanded = true;
-            this.showContent = true;
+            this.expanded_chevron = true;
         } else if (!expandedValue && this._expanded) {
             this._expanded = false;
             setTimeout(() => {
-                this.showContent = false;
+                this.expanded_chevron = false;
             }, 400);
         }
     }
@@ -34,7 +34,7 @@ export class ExpandableDivComponent {
     }
 
     get chevron_class() {
-        return 'expandable-div-chevron '.concat(this.showContent ? 'expanded' : 'collapsed');
+        return 'expandable-div-chevron '.concat(this.expanded_chevron ? 'expanded' : 'collapsed');
     }
 
     constructor(private elementRef: ElementRef) { }

--- a/src/lib/controls/expandableDiv/expandableDiv.component.ts
+++ b/src/lib/controls/expandableDiv/expandableDiv.component.ts
@@ -6,23 +6,17 @@ import { Input, Component, HostBinding, ContentChild, ElementRef, Output, EventE
     templateUrl: './expandableDiv.component.html',
 })
 export class ExpandableDivComponent {
-    private expanded_chevron: boolean;
+    @HostBinding('class.expandable-div--collapsed') private collapsed = true;
+    @HostBinding('class.expandable-div--expanded') private _expanded: boolean;
+    @HostBinding('class.expandable-div') private expandableDivClass = true;
 
     @Output() expandedChanged: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-    @HostBinding('class.expandable-div--expanded') private _expanded: boolean;
-    @HostBinding('class.expandable-div') private expandableDivClass = true;
-    @HostBinding('class.expandable-div--collapsed') isCollapsed() { return !this._expanded; }
-
     @Input() set expanded(expandedValue: boolean) {
         if (expandedValue && !this._expanded) {
-            this._expanded = true;
-            this.expanded_chevron = true;
+            this.expand();
         } else if (!expandedValue && this._expanded) {
-            this._expanded = false;
-            setTimeout(() => {
-                this.expanded_chevron = false;
-            }, 400);
+            this.collapse();
         }
     }
 
@@ -31,9 +25,40 @@ export class ExpandableDivComponent {
     }
 
     get chevron_class() {
-        return 'expandable-div-chevron '.concat(this.expanded_chevron ? 'expanded' : 'collapsed');
+        return 'expandable-div-chevron '.concat(this.expanded ? 'expanded' : 'collapsed');
     }
 
     constructor(private elementRef: ElementRef) { }
+
+    collapse() {
+        this.collapseContent(() => {
+            const expandedChanged = this._expanded;
+            this._expanded = false;
+            this.collapsed = true;
+            if (expandedChanged) {
+                this.expandedChanged.emit(this._expanded);
+            }
+        });
+    }
+
+    expand() {
+        this.expandContent();
+        const expandedChanged = !this._expanded;
+        this._expanded = true;
+        this.collapsed = false;
+        if (expandedChanged) {
+            this.expandedChanged.emit(this._expanded);
+        }
+    }
+
+    private collapseContent(callback?: any) {
+        const header = $(this.elementRef.nativeElement).children('.expandable-div-header');
+        header.siblings('.expandable-div-content').slideUp(400, callback);
+    }
+
+    private expandContent() {
+        const header = $(this.elementRef.nativeElement).children('.expandable-div-header');
+        header.siblings('.expandable-div-content').slideDown(400);
+    }
 }
 

--- a/src/lib/controls/list-item/list-item-content.component.ts
+++ b/src/lib/controls/list-item/list-item-content.component.ts
@@ -7,6 +7,7 @@ import { Component, HostBinding, Input } from '@angular/core';
 })
 
 export class ListItemContentComponent {
+    @HostBinding('class.list-item__content') listItemContent = true;
     constructor() {
     }
 }

--- a/src/lib/controls/list-item/list-item.component.html
+++ b/src/lib/controls/list-item/list-item.component.html
@@ -11,6 +11,4 @@
     {{notification? notification.message : ''}}
   </div>
 </div>
-<div class="list-item__content">
-  <ng-content *ngIf="expanded" select="vgr-list-item-content"></ng-content>
-</div>
+<ng-content select="vgr-list-item-content"></ng-content>


### PR DESCRIPTION
Då bytet från jQuery till CSS-animationer inte verkar ha påverkat prestandan, men däremot orsakat layout-problem samt hackigare animeringar så revertar vi dessa ändringar och återgår till jQuery för nu.

Framåt är ändå ambitionen att byta ut jQuery till CSS-animationer. Ny branch kommer skapas upp för detta.