### PR TITLE
Skapa möjlighet att ändra animeringshastighet för ListItemComponent via input till dito

### DIFF
--- a/projects/komponentkartan/src/lib/controls/list-item/list-item.component.html
+++ b/projects/komponentkartan/src/lib/controls/list-item/list-item.component.html
@@ -9,6 +9,6 @@
     {{notification? notification.message : ''}}
   </div>
 </div>
-<div [@slideListContent]="stateName" (@slideListContent.done)="animationDone($event)" (@slideListContent.start)="animationStart($event)">
+<div [@slideListContent]="{value: stateName, params: {animationSpeed: animationSpeed}}" (@slideListContent.done)="animationDone($event)" (@slideListContent.start)="animationStart($event)">
   <ng-content select="vgr-list-item-content"></ng-content>
 </div>

--- a/projects/komponentkartan/src/lib/controls/list-item/list-item.component.ts
+++ b/projects/komponentkartan/src/lib/controls/list-item/list-item.component.ts
@@ -29,11 +29,11 @@ import { ListItemContentComponent } from '../list-item/list-item-content.compone
             })),
             transition('expanded => collapsed', [
                 style({overflow: 'hidden'}),
-                animate('400ms ease-out')
+                animate('{{animationSpeed}}ms ease-out')
             ]),
             transition('collapsed => expanded', [
                 style({overflow: 'hidden'}),
-                animate('400ms ease-in')
+                animate('{{animationSpeed}}ms ease-in')
             ]),
         ])
     ]
@@ -59,7 +59,7 @@ export class ListItemComponent implements AfterContentInit {
     @ContentChild(ListItemHeaderComponent) listItemHeader: ListItemHeaderComponent;
     @ContentChild(ListItemContentComponent) listContent: ListItemContentComponent;
 
-
+    @Input() animationSpeed = 400; // Default
 
     @Input() set expanded(expandedValue: boolean) {
         if (expandedValue && !this._expanded) {
@@ -190,7 +190,7 @@ export class ListItemComponent implements AfterContentInit {
                 if (expandedChanged) {
                     this.expandedChanged.emit(this._expanded);
                 }
-            }, 400);
+            }, this.animationSpeed);
         }
     }
 


### PR DESCRIPTION
Idag är 400 + 400 ms tills komponenten har minimerat färdigt ganska lång tid. En möjlighet att ändra denna tid vore önskärt. Detta förslag innebär att minskningen av marginalerna till intilliggande element tar vid när minimeringen av ListItemContentComponent är klar. Om input sätts till 100 så kommer det alltså ta 100 + 100 ms tills hela animeringen är klar. Detta förslag förändrar inte rotationen av chevron-ikonen då det sker via css.