### PR TITLE
Uppdatera utseende av knappar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Change-log](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 6.0.1
+## 6.1.0
 - Updated design of `vgr-button`
 
 ## 6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Change-log](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 6.0.1
+- Updated design of `vgr-button`
+
 ## 6.0.0
 - *Breaking change* Angular is upgraded to version 8.
 - *Breaking change* `title-value` is now declarative using: `title-value-heading` and `title-value-container` as children.

--- a/projects/komponentkartan/src/assets/partials/_components.button-base.scss
+++ b/projects/komponentkartan/src/assets/partials/_components.button-base.scss
@@ -40,8 +40,8 @@
     z-index: $layer-two;
     bottom: 0;
     left: 0;
-    border-bottom-left-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
   }
   .button__fixIE {
     position: relative;

--- a/projects/komponentkartan/src/assets/partials/_components.button.scss
+++ b/projects/komponentkartan/src/assets/partials/_components.button.scss
@@ -59,11 +59,12 @@
     padding-left: 17px;
     padding-right: 17px;
     &.button--disabled {
-      color: $control-color--disabled;
-      background-color: $text-color--light;
-      border-color: $control-color--disabled;
+      border: none;
+      background-color: $control-color--disabled;
+      cursor: default;
+      color: #fff;
     }
-    &:hover:not(.button--disabled),
+      &:hover:not(.button--disabled),
     &:focus:not(.button--disabled) {
       @extend .background-color--primary;
       color: $text-color--light;

--- a/projects/komponentkartan/src/assets/partials/_components.button.scss
+++ b/projects/komponentkartan/src/assets/partials/_components.button.scss
@@ -44,6 +44,7 @@
   min-width: 87px;
   padding-left: 18px;
   padding-right: 18px;
+  border-radius: 4px;
   &.button--enabling {
     animation: button-enabling 0.6s;
     transition: background-color 0.4s ease;

--- a/projects/komponentkartan/src/assets/partials/_components.button.scss
+++ b/projects/komponentkartan/src/assets/partials/_components.button.scss
@@ -3,6 +3,7 @@
     0% {
       background-color: $text-color--light;
     }
+
     50% {
       box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.5);
       background-color: $color;
@@ -11,6 +12,7 @@
       border-style: solid;
       color: $text-color--light;
     }
+
     100% {
       background-color: $text-color--light;
     }
@@ -27,9 +29,11 @@
   0% {
     box-shadow: none;
   }
+
   50% {
     box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.5);
   }
+
   100% {
     box-shadow: none;
   }
@@ -45,10 +49,12 @@
   padding-left: 18px;
   padding-right: 18px;
   border-radius: 4px;
+
   &.button--enabling {
     animation: button-enabling 0.6s;
     transition: background-color 0.4s ease;
   }
+
   &.button--secondary {
     @extend .color--primary;
     @extend .border-color--primary;
@@ -58,34 +64,41 @@
     border-style: solid;
     padding-left: 17px;
     padding-right: 17px;
+
     &.button--disabled {
       border: none;
       background-color: $control-color--disabled;
       cursor: default;
       color: #fff;
     }
-      &:hover:not(.button--disabled),
-    &:focus:not(.button--disabled) {
+
+    &:hover:not(.button--disabled) {
       @extend .background-color--primary;
       color: $text-color--light;
       transition: background-color 0.5s ease, color 0.5s ease;
     }
+
     &.button--enabling {
       animation: button-enabling--secondary-neutral 0.9s;
+
       .theme--red & {
         animation: button-enabling--secondary-red 0.9s;
       }
+
       .theme--blue & {
         animation: button-enabling--secondary-blue 0.9s;
       }
+
       .theme--green & {
         animation: button-enabling--secondary-green 0.9s;
       }
+
       .theme--pinkie & {
         animation: button-enabling--secondary-pinkie 0.9s;
       }
     }
   }
+
   &.button--discreet {
     @extend .color--primary;
     border-color: transparent;
@@ -96,13 +109,16 @@
     min-width: 20px;
     padding-left: 10px;
     padding-right: 10px;
+
     &.button--disabled {
       color: $control-color--disabled;
     }
+
     &.button--enabling {
       animation: none;
       transition: color 0.6s ease;
     }
+
     &:hover:not(.button--disabled),
     &:focus:not(.button--disabled) {
       @extend .background-color--primary-dimmed;
@@ -117,6 +133,7 @@
     padding-left: 22px;
     padding-right: 22px;
     font-size: $font-size--medium;
+
     &.button--secondary {
       padding-left: 21px;
       padding-right: 21px;


### PR DESCRIPTION
✔️ Hörnets rundning är 4 px
✔️ Hover-effekten följer rundningen
✔️ Fokus på sekundärknappen ger bara en outline
✔️ Hover på sekundärknappen byter bakgrundsfärgen
✔️ När sekundärknappen är inaktiv har den samma inaktiva utseende som primärknappen