### PR TITLE
Fix/374 improve visibility of keyboard activated buttons

### DIFF
--- a/projects/komponentkartan/src/assets/partials/_components.button-base.scss
+++ b/projects/komponentkartan/src/assets/partials/_components.button-base.scss
@@ -13,7 +13,7 @@
     box-shadow: none;
     outline: $focus-outline-width solid $focus-color;
   }
-  &:active:not(.button--disabled) {
+  &:active:not(.button--disabled), &.button--active {
     box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.5);
     transform: scale(0.96);
     outline: 0;

--- a/projects/komponentkartan/src/lib/controls/button/button.component.html
+++ b/projects/komponentkartan/src/lib/controls/button/button.component.html
@@ -4,7 +4,8 @@
    class="button noselect"
    [attr.aria-disabled]="disabled"
    [disabled]="disabled"
-   [ngClass]="calculateClasses()">
+   [ngClass]="calculateClasses()"
+   (keydown)="onKeyboardActivation($event)">
     <span class="button__fixIE">
       <ng-content></ng-content>
     </span>

--- a/projects/komponentkartan/src/lib/controls/button/button.component.ts
+++ b/projects/komponentkartan/src/lib/controls/button/button.component.ts
@@ -11,6 +11,7 @@ export class ButtonComponent implements OnChanges {
   @ViewChild('button', { static: true }) button: ElementRef;
   reenabled = false;
   private wasDisabled = false;
+  private activated = false;
 
   ngOnChanges() {
     this.reenabled = this.wasDisabled && !this.disabled;
@@ -27,11 +28,21 @@ export class ButtonComponent implements OnChanges {
     this.button.nativeElement.focus();
   }
 
+  onKeyboardActivation(e: KeyboardEvent): void {
+    if (e.key === ' ' || e.key === 'Enter') {
+      this.activated = true;
+      setTimeout(() => {
+        this.activated = false;
+      }, 500);
+    }
+  }
+
   calculateClasses() {
     return { 'button--disabled' : this.disabled,
     'button--enabling' : this.reenabled,
     'button--secondary': this.buttonStyle === 'secondary',
-    'button--discreet': this.buttonStyle === 'discreet'
+    'button--discreet': this.buttonStyle === 'discreet',
+    'button--active': this.activated
     };
   }
 }


### PR DESCRIPTION
När knappen aktiveras med space eller enter läggs en klass till på knappen så att den ser intryckt ut. Efter en kort stund tas klassen bort och knappen återgår till normalt utseende. 

closes #374 