### PR TITLE
Fixa tabb-ordningen på filter-tags

### DIFF
--- a/projects/komponentkartan/src/lib/controls/filter-tag/filter-tag-group.component.ts
+++ b/projects/komponentkartan/src/lib/controls/filter-tag/filter-tag-group.component.ts
@@ -35,9 +35,8 @@ export class FilterTagGroupComponent implements AfterContentInit, OnDestroy {
   }
 
   setFilterTagTabFocusability() {
-    this.filterTags.forEach((x, i) => {
-      const focusable = i ? false : true;
-      x.makeTabFocusable(focusable);
+    this.filterTags.forEach((x) => {
+      x.makeTabFocusable(true);
     });
   }
 


### PR DESCRIPTION
Den tidigare logiken för att sätta "focusable" på en filter-tag gjorde så att bara den 0:te elementet kunde fokuseras. Jag tog bort det och satte true på alla filter-tag-element. Jag kunde inte hitta någon anledning att en filter-tag _inte_ ska kunna fokuseras. 