### PR TITLE
Fix/button style breaks with compiler optimization

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -82,6 +82,9 @@
           "configurations": {
             "production": {
               "browserTarget": "app:build:production"
+            },
+            "dev": {
+              "browserTarget": "app:build:dev"
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "start-develop": "ng serve --configuration=dev",
     "build": "ng build --prod",
     "test": "npm run test-ci",
     "lint": "ng lint",

--- a/projects/komponentkartan/src/lib/controls/button/button.component.ts
+++ b/projects/komponentkartan/src/lib/controls/button/button.component.ts
@@ -1,4 +1,5 @@
 ﻿import { Component, Input, OnChanges, ViewChild, ElementRef } from '@angular/core';
+import { mapToClassString } from '../../utils/map-to-class-string';
 
 @Component({
   selector: 'vgr-button',
@@ -38,11 +39,14 @@ export class ButtonComponent implements OnChanges {
   }
 
   calculateClasses() {
-    return { 'button--disabled' : this.disabled,
-    'button--enabling' : this.reenabled,
-    'button--secondary': this.buttonStyle === 'secondary',
-    'button--discreet': this.buttonStyle === 'discreet',
-    'button--active': this.activated
-    };
+    const css = new Map([
+      ['button--disabled', this.disabled],
+      ['button--enabling', this.reenabled],
+      ['button--secondary', this.buttonStyle === 'secondary'],
+      ['button--discreet', this.buttonStyle === 'discreet'],
+      ['button--active', this.activated]
+    ]);
+
+    return mapToClassString(css);
   }
 }

--- a/projects/komponentkartan/src/lib/controls/button/button.component.ts
+++ b/projects/komponentkartan/src/lib/controls/button/button.component.ts
@@ -11,8 +11,8 @@ export class ButtonComponent implements OnChanges {
   @Input() type = 'button';
   @ViewChild('button', { static: true }) button: ElementRef;
   reenabled = false;
-  activated = false;
   private wasDisabled = false;
+  private activated = false;
 
   ngOnChanges() {
     this.reenabled = this.wasDisabled && !this.disabled;

--- a/projects/komponentkartan/src/lib/controls/button/button.component.ts
+++ b/projects/komponentkartan/src/lib/controls/button/button.component.ts
@@ -10,8 +10,8 @@ export class ButtonComponent implements OnChanges {
   @Input() type = 'button';
   @ViewChild('button', { static: true }) button: ElementRef;
   reenabled = false;
+  activated = false;
   private wasDisabled = false;
-  private activated = false;
 
   ngOnChanges() {
     this.reenabled = this.wasDisabled && !this.disabled;

--- a/projects/komponentkartan/src/lib/utils/map-to-class-string.ts
+++ b/projects/komponentkartan/src/lib/utils/map-to-class-string.ts
@@ -1,0 +1,10 @@
+export function mapToClassString(input: Map<string, boolean>): string {
+  const classes = [];
+    for (const [key, value] of input) {
+      if (value) {
+        classes.push(key);
+      }
+    }
+
+  return classes.join(' ');
+}


### PR DESCRIPTION
Vi upptäckte att styling på knappar (vgr-button) slutade funka om man sätter `optimization: true` i angular.json i en konsument av komponentkartan. 

Efter idogt felsökande (tack @AronssonFredrik ) kom vi fram till att det inte funkar att returnera ett objekt: 

```
{ 
   'button--disabled': this.disabled,
   ...
} 
``` 
till `ngClass` om optimization är true. För att komma förbi detta, men ändå kunna undvika att `ngClass` har hela "css-objektet" direkt i template, kom jag med denna lösning. 

Detta är testat i VEPClient i Chrome och IE. 
