### PR TITLE
Filter-tag: Handle focus in IE

### DIFF
--- a/projects/komponentkartan/src/lib/controls/filter-tag/filter-tag-group.component.ts
+++ b/projects/komponentkartan/src/lib/controls/filter-tag/filter-tag-group.component.ts
@@ -46,6 +46,7 @@ export class FilterTagGroupComponent implements AfterContentInit, OnDestroy {
       if (this.lastSelectedIndex < nonRemovedFilterTags.length) {
         nonRemovedFilterTags[this.lastSelectedIndex].focus();
       } else if (nonRemovedFilterTags.length) {
+        this.lastSelectedIndex = nonRemovedFilterTags.length - 1;
         nonRemovedFilterTags[nonRemovedFilterTags.length - 1].focus();
       }
     }

--- a/projects/komponentkartan/src/lib/controls/filter-tag/filter-tag.component.ts
+++ b/projects/komponentkartan/src/lib/controls/filter-tag/filter-tag.component.ts
@@ -41,7 +41,22 @@ export class FilterTagComponent implements AfterViewInit {
   }
 
   focus() {
-    this.filtertag.nativeElement.focus();
+    // TODO: Remove this as soon as IE11
+    // support is dropped.
+    //
+    // focus() does not work in IE11 unless
+    // set after a short delay. Wrap in if
+    // to not do this in better browsers.
+    const re = /Trident\/7/;
+    const isIE11 = re.test(window.navigator.userAgent);
+
+    if (isIE11) {
+      setTimeout(() => {
+        this.filtertag.nativeElement.focus();
+      }, 5);
+    } else {
+      this.filtertag.nativeElement.focus();
+    }
   }
 
   emitRemove() {

--- a/projects/komponentkartan/src/lib/controls/filter-tag/filter-tag.component.ts
+++ b/projects/komponentkartan/src/lib/controls/filter-tag/filter-tag.component.ts
@@ -41,11 +41,8 @@ export class FilterTagComponent implements AfterViewInit {
   }
 
   focus() {
-    // TODO: Remove this as soon as IE11
-    // support is dropped.
-    //
     // focus() does not work in IE11 unless
-    // set after a short delay. Wrap in if
+    // called after a short delay. Wrap in if
     // to not do this in better browsers.
     const re = /Trident\/7/;
     const isIE11 = re.test(window.navigator.userAgent);


### PR DESCRIPTION
#309 

Ett litet hack för att få tabindex i filtertags att funka i IE11. Testat i Chrome, Edge (nya och gamla) och IE11. 